### PR TITLE
Do not `path.skip()` for `constObject`

### DIFF
--- a/src/const-object.js
+++ b/src/const-object.js
@@ -14,7 +14,6 @@ export default {
           ),
         ]),
       );
-      path.skip();
     }
   },
 };


### PR DESCRIPTION
Allow further transpilation of the `constObject`.

Resolves: #18