### PR TITLE
Bugfix/#20 typescript export scope

### DIFF
--- a/__tests__/__snapshots__/const-object.js.snap
+++ b/__tests__/__snapshots__/const-object.js.snap
@@ -45,8 +45,7 @@ exports[`Transforms no initializers 1`] = `
   Right: 1,
   Down: 2,
   Up: 3
-};
-;"
+};"
 `;
 
 exports[`Transforms string literal properties 1`] = `

--- a/__tests__/__snapshots__/const-object.js.snap
+++ b/__tests__/__snapshots__/const-object.js.snap
@@ -11,6 +11,16 @@ exports[`Transforms \`declare const enum\` 1`] = `
 };"
 `;
 
+exports[`Transforms \`export default\` with \`@babel/plugin-transform-typescript\` 1`] = `
+"const Direction = {
+  Left: 0,
+  Right: 1,
+  Down: 2,
+  Up: 3
+};
+export default Direction;"
+`;
+
 exports[`Transforms chained computed members 1`] = `
 "const MyEnum = {
   A: 1,

--- a/__tests__/__snapshots__/remove-const.js.snap
+++ b/__tests__/__snapshots__/remove-const.js.snap
@@ -45,8 +45,7 @@ exports[`Transforms no initializers 1`] = `
   Right,
   Down,
   Up,
-}
-;"
+}"
 `;
 
 exports[`Transforms string literal properties 1`] = `

--- a/__tests__/const-object.js
+++ b/__tests__/const-object.js
@@ -165,3 +165,16 @@ return MyEnum;
   expect(MyEnum.E).toBe(1);
   expect(MyEnum.F).toBe(2);
 });
+
+const typescriptOptions = {
+  plugins: [...options.plugins, '@babel/transform-typescript'],
+};
+
+it('Transforms `export default` with `@babel/plugin-transform-typescript`', async () => {
+  const input = `const enum Direction { Left, Right, Down, Up }
+export default Direction
+`;
+
+  const { code: output } = await transformAsync(input, typescriptOptions);
+  expect(output).toMatchSnapshot();
+});

--- a/__tests__/const-object.js
+++ b/__tests__/const-object.js
@@ -6,7 +6,7 @@ const options = {
 };
 
 it('Transforms no initializers', async () => {
-  const input = `const enum Direction { Left, Right, Down, Up };
+  const input = `const enum Direction { Left, Right, Down, Up }
 `;
 
   const { code: output } = await transformAsync(input, options);

--- a/__tests__/remove-const.js
+++ b/__tests__/remove-const.js
@@ -6,7 +6,7 @@ const options = {
 };
 
 it('Transforms no initializers', async () => {
-  const input = `const enum Direction { Left, Right, Down, Up };
+  const input = `const enum Direction { Left, Right, Down, Up }
 `;
 
   const { code: output } = await transformAsync(input, options);

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@babel/cli": "^7.5.0",
     "@babel/core": "^7.5.0",
     "@babel/generator": "^7.5.0",
+    "@babel/plugin-transform-typescript": "^7.9.4",
     "@babel/preset-env": "^7.5.0",
     "babel-jest": "^25.2.6",
     "jest": "^25.2.7",

--- a/src/const-object.js
+++ b/src/const-object.js
@@ -4,7 +4,8 @@ import generate from '@babel/generator';
 export default {
   TSEnumDeclaration(path) {
     if (path.node.const) {
-      path.replaceWith(
+      // `path === constObjectPath` for `replaceWith`.
+      const [constObjectPath] = path.replaceWith(
         types.variableDeclaration('const', [
           types.variableDeclarator(
             types.identifier(path.node.id.name),
@@ -14,6 +15,7 @@ export default {
           ),
         ]),
       );
+      path.scope.registerDeclaration(constObjectPath);
     }
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -92,6 +92,18 @@
     levenary "^1.1.1"
     semver "^5.5.0"
 
+"@babel/helper-create-class-features-plugin@^7.8.3":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.9.5.tgz#79753d44017806b481017f24b02fd4113c7106ea"
+  integrity sha512-IipaxGaQmW4TfWoXdqjY0TzoXQ1HRS0kPpEgvjosb3u7Uedcq297xFqDQiCcQtRRwzIMif+N1MLVI8C5a4/PAA==
+  dependencies:
+    "@babel/helper-function-name" "^7.9.5"
+    "@babel/helper-member-expression-to-functions" "^7.8.3"
+    "@babel/helper-optimise-call-expression" "^7.8.3"
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/helper-replace-supers" "^7.8.6"
+    "@babel/helper-split-export-declaration" "^7.8.3"
+
 "@babel/helper-create-regexp-features-plugin@^7.8.3", "@babel/helper-create-regexp-features-plugin@^7.8.8":
   version "7.8.8"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.8.tgz#5d84180b588f560b7864efaeea89243e58312087"
@@ -405,7 +417,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-syntax-typescript@^7.3.3":
+"@babel/plugin-syntax-typescript@^7.3.3", "@babel/plugin-syntax-typescript@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.8.3.tgz#c1f659dda97711a569cef75275f7e15dcaa6cabc"
   integrity sha512-GO1MQ/SGGGoiEXY0e0bSpHimJvxqB7lktLLIq2pv8xG7WZ8IMEle74jIe1FhprHBWjwjZtXHkycDLZXIWM5Wfg==
@@ -647,6 +659,15 @@
   integrity sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
+
+"@babel/plugin-transform-typescript@^7.9.4":
+  version "7.9.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.9.4.tgz#4bb4dde4f10bbf2d787fce9707fb09b483e33359"
+  integrity sha512-yeWeUkKx2auDbSxRe8MusAG+n4m9BFY/v+lPjmQDgOFX5qnySkUY5oXzkp6FwPdsYqnKay6lorXYdC0n3bZO7w==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.8.3"
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-syntax-typescript" "^7.8.3"
 
 "@babel/plugin-transform-unicode-regex@^7.8.3":
   version "7.8.3"


### PR DESCRIPTION
The newly created `constObject` should be registered in babel's scope. If not registered, old versions of `@babel/plugin-transform-typescript` will remove an `export` of the `constObject`, thinking that it is a `type`. Newer versions of `@babel/plugin-transform-typescript` will output a warning.