### PR TITLE
Moving @babel/generator to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
     "@babel/core": "^7.0.0-0"
   },
   "dependencies": {
+    "@babel/generator": "^7.5.0",
     "@babel/helper-plugin-utils": "^7.0.0",
     "@babel/plugin-syntax-typescript": "^7.3.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.0",
     "@babel/core": "^7.5.0",
-    "@babel/generator": "^7.5.0",
     "@babel/plugin-transform-typescript": "^7.9.4",
     "@babel/preset-env": "^7.5.0",
     "babel-jest": "^26.6.3",


### PR DESCRIPTION
Moving @babel/generator from `devDependencies` to `dependencies`.

`@babel/generator` is used inside of `const-object.js` here:
https://github.com/dosentmatter/babel-plugin-const-enum/blob/master/src/const-object.js#L2

Which makes it a dependency of this package, not a dev dependency.

This makes this package currently hard to use with Yarn v2 because Yarn v2 needs dependencies to be explicitly declared in `dependencies` in order for it to resolve those dependencies in a non-ambiguous way.