### PR TITLE
Change `eval` to `new Function`

### DIFF
--- a/src/const-object.js
+++ b/src/const-object.js
@@ -117,7 +117,7 @@ const computeValueNodeFromEnumMemberPath = (
 
       initializerPath.traverse(accessConstEnumMemberVisitor, { constEnum });
 
-      value = eval(generate(initializer).code);
+      value = new Function(`return ${generate(initializer).code}`)();
     } else {
       throw initializerPath.buildCodeFrameError(
         'const enum member initializers can only contain literal values and other computed enum values.',


### PR DESCRIPTION
See:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#never_use_eval!