### PR TITLE
Reuse AST for Initializer Eval

### DIFF
--- a/__tests__/__snapshots__/const-object.js.snap
+++ b/__tests__/__snapshots__/const-object.js.snap
@@ -68,7 +68,7 @@ exports[`Transforms computed members 1`] = `
 };"
 `;
 
-exports[`Transforms computed members 2`] = `
+exports[`Transforms computed members with supported operators 1`] = `
 "const MyEnum = {
   A: 5,
   B: 7

--- a/__tests__/const-object.js
+++ b/__tests__/const-object.js
@@ -2,6 +2,11 @@
 
 import { transformAsync } from '@babel/core';
 import plugin from '../src';
+import {
+  DISALLOWED_NAN_ERROR_MESSAGE,
+  DISALLOWED_INFINITY_ERROR_MESSAGE,
+  NON_NUMERIC_EXPRESSION_ERROR_MESSAGE,
+} from '../src/const-object';
 
 const options = {
   plugins: [[plugin, { transform: 'constObject' }]],
@@ -104,10 +109,25 @@ return MyEnum;
   expect(MyEnum.B).toBe(7);
 });
 
-const DISALLOWED_NAN_ERROR_MESSAGE =
-  "'const' enum member initializer was evaluated to disallowed value 'NaN'.";
-const DISALLOWED_INFINITY_ERROR_MESSAGE =
-  "'const' enum member initializer was evaluated to a non-finite value.";
+it('Transform fails for unsupported operators', async () => {
+  let input;
+
+  input = `const enum MyEnum {
+  A = 1 === 1,
+}
+`;
+  await expect(transformAsync(input, options)).rejects.toThrow(
+    NON_NUMERIC_EXPRESSION_ERROR_MESSAGE,
+  );
+
+  input = `const enum MyEnum {
+  A = 1 + (1 > 1),
+}
+`;
+  await expect(transformAsync(input, options)).rejects.toThrow(
+    NON_NUMERIC_EXPRESSION_ERROR_MESSAGE,
+  );
+});
 
 it('Transform fails for `NaN` and `Infinity` computed members', async () => {
   let input;

--- a/__tests__/const-object.js
+++ b/__tests__/const-object.js
@@ -85,7 +85,7 @@ return MyEnum;
   expect(MyEnum.I).toBe(1048576);
 });
 
-it('Transforms computed members', async () => {
+it('Transforms computed members with supported operators', async () => {
   const input = `const enum MyEnum {
   A = -13 + +12 - ~11 / 10 % 9 * 8 ** 7 & 6 | 5 >> 4 >>> 3 << 2 ^ 1,
   B = -(13 + +12 - ~11 / 10) % (9 * 8) ** 7 & 6 | 5 >> 4 >>> 3 << 2 ^ 1,

--- a/__tests__/const-object.js
+++ b/__tests__/const-object.js
@@ -116,7 +116,7 @@ it('Transform fails for `NaN` and `Infinity` computed members', async () => {
   A = NaN,
 }
 `;
-  expect(transformAsync(input, options)).rejects.toThrow(
+  await expect(transformAsync(input, options)).rejects.toThrow(
     DISALLOWED_NAN_ERROR_MESSAGE,
   );
 
@@ -124,7 +124,7 @@ it('Transform fails for `NaN` and `Infinity` computed members', async () => {
   A = Infinity,
 }
 `;
-  expect(transformAsync(input, options)).rejects.toThrow(
+  await expect(transformAsync(input, options)).rejects.toThrow(
     DISALLOWED_INFINITY_ERROR_MESSAGE,
   );
 
@@ -132,7 +132,7 @@ it('Transform fails for `NaN` and `Infinity` computed members', async () => {
   A = 0 / 0,
 }
 `;
-  expect(transformAsync(input, options)).rejects.toThrow(
+  await expect(transformAsync(input, options)).rejects.toThrow(
     DISALLOWED_NAN_ERROR_MESSAGE,
   );
 

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "@babel/core": "^7.0.0-0"
   },
   "dependencies": {
-    "@babel/generator": "^7.5.0",
     "@babel/helper-plugin-utils": "^7.0.0",
-    "@babel/plugin-syntax-typescript": "^7.3.3"
+    "@babel/plugin-syntax-typescript": "^7.3.3",
+    "@babel/traverse": "^7.16.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.0",

--- a/src/const-object.js
+++ b/src/const-object.js
@@ -191,12 +191,14 @@ const isNumericUnaryExpression = (node) =>
 const isNumericBinaryExpression = (node) =>
   types.isBinaryExpression(node) && BINARY_OPERATORS.has(node.operator);
 
-const validateIdentifierName = (path) => {
-  switch (path.node.name) {
+const validateIdentifierName = (identifierPath) => {
+  switch (identifierPath.node.name) {
     case 'NaN':
-      throw path.buildCodeFrameError(DISALLOWED_NAN_ERROR_MESSAGE);
+      throw identifierPath.buildCodeFrameError(DISALLOWED_NAN_ERROR_MESSAGE);
     case 'Infinity':
-      throw path.buildCodeFrameError(DISALLOWED_INFINITY_ERROR_MESSAGE);
+      throw identifierPath.buildCodeFrameError(
+        DISALLOWED_INFINITY_ERROR_MESSAGE,
+      );
   }
 };
 

--- a/src/const-object.js
+++ b/src/const-object.js
@@ -146,7 +146,7 @@ const computeValueNodeFromEnumMemberPath = (
     valueNode = types.stringLiteral(value);
   } else if (Number.isNaN(value)) {
     throw tsEnumMemberPath.buildCodeFrameError(DISALLOWED_NAN_ERROR_MESSAGE);
-  } else if (!Number.isFinite(value)) {
+  } else if (value === Infinity || value === -Infinity) {
     throw tsEnumMemberPath.buildCodeFrameError(
       DISALLOWED_INFINITY_ERROR_MESSAGE,
     );

--- a/src/const-object.js
+++ b/src/const-object.js
@@ -1,10 +1,12 @@
 import { types } from '@babel/core';
-import generate from '@babel/generator';
+import traverse from '@babel/traverse';
 
-const DISALLOWED_NAN_ERROR_MESSAGE =
+export const DISALLOWED_NAN_ERROR_MESSAGE =
   "'const' enum member initializer was evaluated to disallowed value 'NaN'.";
-const DISALLOWED_INFINITY_ERROR_MESSAGE =
+export const DISALLOWED_INFINITY_ERROR_MESSAGE =
   "'const' enum member initializer was evaluated to a non-finite value.";
+export const NON_NUMERIC_EXPRESSION_ERROR_MESSAGE =
+  'Must be numeric expression.';
 
 export default {
   TSEnumDeclaration(path) {
@@ -112,8 +114,8 @@ const computeValueNodeFromEnumMemberPath = (
       value = constEnum[initializer.name];
       validateConstEnumMemberAccess(tsEnumMemberPath, value);
     } else if (
-      isNumericUnaryExpression(initializer) ||
-      isNumericBinaryExpression(initializer)
+      types.isUnaryExpression(initializer) ||
+      types.isBinaryExpression(initializer)
     ) {
       if (isStringEnum) {
         throw initializerPath.buildCodeFrameError(
@@ -121,9 +123,11 @@ const computeValueNodeFromEnumMemberPath = (
         );
       }
 
-      initializerPath.traverse(accessConstEnumMemberVisitor, { constEnum });
+      traverseFromRoot(initializerPath, accessConstEnumMemberVisitor, {
+        constEnum,
+      });
 
-      value = new Function(`return ${generate(initializer).code}`)();
+      value = evaluateInitializer(initializerPath);
     } else {
       throw initializerPath.buildCodeFrameError(
         'const enum member initializers can only contain literal values and other computed enum values.',
@@ -168,28 +172,34 @@ const getValueFromValueNode = (valueNode) => {
   return value;
 };
 
-const UNARY_OPERATORS = new Set(['+', '-', '~']);
+const UNARY_OPERATORS = {
+  '+': (a) => +a,
+  '-': (a) => -a,
+  '~': (a) => ~a,
+};
 
-const BINARY_OPERATORS = new Set([
-  '+',
-  '-',
-  '/',
-  '%',
-  '*',
-  '**',
-  '&',
-  '|',
-  '>>',
-  '>>>',
-  '<<',
-  '^',
-]);
+const BINARY_OPERATORS = {
+  '+': (a, b) => a + b,
+  '-': (a, b) => a - b,
+  '/': (a, b) => a / b,
+  '%': (a, b) => a % b,
+  '*': (a, b) => a * b,
+  '**': (a, b) => a ** b,
+  '&': (a, b) => a & b,
+  '|': (a, b) => a | b,
+  '>>': (a, b) => a >> b,
+  '>>>': (a, b) => a >>> b,
+  '<<': (a, b) => a << b,
+  '^': (a, b) => a ^ b,
+};
 
 const isNumericUnaryExpression = (node) =>
-  types.isUnaryExpression(node) && UNARY_OPERATORS.has(node.operator);
+  types.isUnaryExpression(node) &&
+  Object.prototype.hasOwnProperty.call(UNARY_OPERATORS, node.operator);
 
 const isNumericBinaryExpression = (node) =>
-  types.isBinaryExpression(node) && BINARY_OPERATORS.has(node.operator);
+  types.isBinaryExpression(node) &&
+  Object.prototype.hasOwnProperty.call(BINARY_OPERATORS, node.operator);
 
 const validateIdentifierName = (identifierPath) => {
   switch (identifierPath.node.name) {
@@ -210,6 +220,23 @@ const validateConstEnumMemberAccess = (path, value) => {
   }
 };
 
+const traverseFromRoot = (path, visitor, state) => {
+  visitor = traverse.visitors.explode(visitor);
+  if (visitor.enter) {
+    visitor.enter[0].call(state, path, state);
+  }
+  if (visitor[path.type] && visitor[path.type].enter) {
+    visitor[path.type].enter[0].call(state, path, state);
+  }
+  path.traverse(visitor, state);
+  if (visitor.exit) {
+    visitor.exit[0].call(state, path, state);
+  }
+  if (visitor[path.type] && visitor[path.type].exit) {
+    visitor[path.type].exit[0].call(state, path, state);
+  }
+};
+
 const accessConstEnumMemberVisitor = {
   enter(path) {
     if (types.isIdentifier(path.node)) {
@@ -227,7 +254,35 @@ const accessConstEnumMemberVisitor = {
         isNumericBinaryExpression(path.node)
       )
     ) {
-      throw path.buildCodeFrameError('Must be numeric expression.');
+      throw path.buildCodeFrameError(NON_NUMERIC_EXPRESSION_ERROR_MESSAGE);
     }
+  },
+};
+
+const evaluateInitializer = (initializerPath) => {
+  traverseFromRoot(initializerPath, evaluateInitializerVisitor);
+  return initializerPath.node.value;
+};
+
+const evaluateInitializerVisitor = {
+  UnaryExpression: {
+    exit(path) {
+      const { node } = path;
+      path.replaceWith(
+        types.numericLiteral(
+          UNARY_OPERATORS[node.operator](node.argument.value),
+        ),
+      );
+    },
+  },
+  BinaryExpression: {
+    exit(path) {
+      const { node } = path;
+      path.replaceWith(
+        types.numericLiteral(
+          BINARY_OPERATORS[node.operator](node.left.value, node.right.value),
+        ),
+      );
+    },
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,6 +32,13 @@
   dependencies:
     "@babel/highlight" "^7.14.5"
 
+"@babel/code-frame@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.0.tgz#0dfc80309beec8411e65e706461c408b0bb9b431"
+  integrity sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==
+  dependencies:
+    "@babel/highlight" "^7.16.0"
+
 "@babel/compat-data@^7.13.11", "@babel/compat-data@^7.14.5", "@babel/compat-data@^7.14.7":
   version "7.14.7"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.14.7.tgz#7b047d7a3a89a67d2258dc61f604f098f1bc7e08"
@@ -58,12 +65,21 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
-"@babel/generator@^7.14.5", "@babel/generator@^7.5.0", "@babel/generator@^7.7.2":
+"@babel/generator@^7.14.5", "@babel/generator@^7.7.2":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.14.5.tgz#848d7b9f031caca9d0cd0af01b063f226f52d785"
   integrity sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==
   dependencies:
     "@babel/types" "^7.14.5"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.16.0.tgz#d40f3d1d5075e62d3500bccb67f3daa8a95265b2"
+  integrity sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==
+  dependencies:
+    "@babel/types" "^7.16.0"
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
@@ -142,6 +158,15 @@
     "@babel/template" "^7.14.5"
     "@babel/types" "^7.14.5"
 
+"@babel/helper-function-name@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz#b7dd0797d00bbfee4f07e9c4ea5b0e30c8bb1481"
+  integrity sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.16.0"
+    "@babel/template" "^7.16.0"
+    "@babel/types" "^7.16.0"
+
 "@babel/helper-get-function-arity@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz#25fbfa579b0937eee1f3b805ece4ce398c431815"
@@ -149,12 +174,26 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
+"@babel/helper-get-function-arity@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz#0088c7486b29a9cb5d948b1a1de46db66e089cfa"
+  integrity sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==
+  dependencies:
+    "@babel/types" "^7.16.0"
+
 "@babel/helper-hoist-variables@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz#e0dd27c33a78e577d7c8884916a3e7ef1f7c7f8d"
   integrity sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==
   dependencies:
     "@babel/types" "^7.14.5"
+
+"@babel/helper-hoist-variables@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz#4c9023c2f1def7e28ff46fc1dbcd36a39beaa81a"
+  integrity sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==
+  dependencies:
+    "@babel/types" "^7.16.0"
 
 "@babel/helper-member-expression-to-functions@^7.14.5":
   version "7.14.7"
@@ -236,10 +275,22 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
+"@babel/helper-split-export-declaration@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz#29672f43663e936df370aaeb22beddb3baec7438"
+  integrity sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==
+  dependencies:
+    "@babel/types" "^7.16.0"
+
 "@babel/helper-validator-identifier@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz#d0f0e277c512e0c938277faa85a3968c9a44c0e8"
   integrity sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==
+
+"@babel/helper-validator-identifier@^7.15.7":
+  version "7.15.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz#220df993bfe904a4a6b02ab4f3385a5ebf6e2389"
+  integrity sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
 
 "@babel/helper-validator-option@^7.14.5":
   version "7.14.5"
@@ -274,10 +325,24 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/highlight@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.16.0.tgz#6ceb32b2ca4b8f5f361fb7fd821e3fddf4a1725a"
+  integrity sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.15.7"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
 "@babel/parser@^7.1.0", "@babel/parser@^7.14.5", "@babel/parser@^7.14.6", "@babel/parser@^7.14.7", "@babel/parser@^7.7.2":
   version "7.14.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.7.tgz#6099720c8839ca865a2637e6c85852ead0bdb595"
   integrity sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==
+
+"@babel/parser@^7.16.0":
+  version "7.16.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.2.tgz#3723cd5c8d8773eef96ce57ea1d9b7faaccd12ac"
+  integrity sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==
 
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.14.5":
   version "7.14.5"
@@ -898,6 +963,15 @@
     "@babel/parser" "^7.14.5"
     "@babel/types" "^7.14.5"
 
+"@babel/template@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.0.tgz#d16a35ebf4cd74e202083356fab21dd89363ddd6"
+  integrity sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==
+  dependencies:
+    "@babel/code-frame" "^7.16.0"
+    "@babel/parser" "^7.16.0"
+    "@babel/types" "^7.16.0"
+
 "@babel/traverse@^7.1.0", "@babel/traverse@^7.13.0", "@babel/traverse@^7.14.5", "@babel/traverse@^7.7.2":
   version "7.14.7"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.14.7.tgz#64007c9774cfdc3abd23b0780bc18a3ce3631753"
@@ -913,12 +987,35 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.16.0.tgz#965df6c6bfc0a958c1e739284d3c9fa4a6e3c45b"
+  integrity sha512-qQ84jIs1aRQxaGaxSysII9TuDaguZ5yVrEuC0BN2vcPlalwfLovVmCjbFDPECPXcYM/wLvNFfp8uDOliLxIoUQ==
+  dependencies:
+    "@babel/code-frame" "^7.16.0"
+    "@babel/generator" "^7.16.0"
+    "@babel/helper-function-name" "^7.16.0"
+    "@babel/helper-hoist-variables" "^7.16.0"
+    "@babel/helper-split-export-declaration" "^7.16.0"
+    "@babel/parser" "^7.16.0"
+    "@babel/types" "^7.16.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.14.5", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.5.tgz#3bb997ba829a2104cedb20689c4a5b8121d383ff"
   integrity sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.14.5"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.16.0.tgz#db3b313804f96aadd0b776c4823e127ad67289ba"
+  integrity sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.15.7"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":


### PR DESCRIPTION
Avoid using `eval()` or `Function()`.

[`vm2`](https://www.npmjs.com/package/vm2) could be used, but it would only work for node and not the browser, which would break this plugin on babel repl web app.